### PR TITLE
ajoute les catégories depuis service de recherche + conversion

### DIFF
--- a/core/entree_carto_custom.py
+++ b/core/entree_carto_custom.py
@@ -105,8 +105,9 @@ def generate_entree_carto_conf(merged_config):
             return thematic
 
     # Map les thématiques avec la table de conversion
-    for layerID, layerParams in edito_config["layers"].items():
-        edito_config["layers"][layerID]["thematic"] = [convertThematic(thematic, convert_table) for thematic in layerParams["thematic"]]
+    if convert_table:
+        for layerID, layerParams in edito_config["layers"].items():
+            edito_config["layers"][layerID]["thematic"] = [convertThematic(thematic, convert_table) for thematic in layerParams["thematic"]]
 
 
     with open("dist/entreeCarto.json", "w", encoding="utf-8") as file:

--- a/core/entree_carto_custom.py
+++ b/core/entree_carto_custom.py
@@ -1,7 +1,7 @@
 import json
 
 from core.config_merger import merge_edito
-from core.requester import getEdito
+from core.requester import getEdito, searchMtdUrls, getThematicConversionTable
 
 def filter_specific_duplicates(input_dict):
     """
@@ -56,6 +56,23 @@ def filter_specific_duplicates(input_dict):
 
 def generate_entree_carto_conf(merged_config):
     edito = getEdito()
+
+    # Récupère les infos idsponibles depuis le service recherche
+    # en particulier "theme" et "producers"
+    mtd_urls_layers = searchMtdUrls()
+    if mtd_urls_layers:
+        for item in mtd_urls_layers:
+            if 'layer_name' in item:
+                layerType = item["type"]
+                layerName = item['layer_name']
+                layerID = layerName + "$GEOPORTAIL:OGC:" + layerType
+                if layerID in merged_config["layers"]:
+                    if 'theme' in item:
+                        merged_config["layers"][layerID]["thematic"] = list(map(str.strip, item["theme"].split(',')))
+                    merged_config["layers"][layerID]["metadata_urls"] = item["metadata_urls"]
+                    if 'producers' in item:
+                        merged_config["layers"][layerID]["producer"] = item["producers"]
+
     if edito:
         edito_config = merge_edito(merged_config, edito)
 
@@ -78,6 +95,19 @@ def generate_entree_carto_conf(merged_config):
     
     # Filtre les couches WMS qui dupliquent une couche WMTS
     edito_config["layers"] = filter_specific_duplicates(edito_config["layers"])
+
+    # Récupère une table de conversion des thématiques
+    convert_table = getThematicConversionTable()
+    def convertThematic(thematic, convert_table):
+        if thematic in convert_table:
+            return convert_table[thematic]
+        else:
+            return thematic
+
+    # Map les thématiques avec la table de conversion
+    for layerID, layerParams in edito_config["layers"].items():
+        edito_config["layers"][layerID]["thematic"] = [convertThematic(thematic, convert_table) for thematic in layerParams["thematic"]]
+
 
     with open("dist/entreeCarto.json", "w", encoding="utf-8") as file:
         file.writelines(json.dumps(edito_config, indent=2, ensure_ascii=False))

--- a/core/requester.py
+++ b/core/requester.py
@@ -88,3 +88,46 @@ def getEdito():
     if response.status_code != 200:
         return False
     return response.json()
+
+def getThematicConversionTable():
+    url = "https://raw.githubusercontent.com/IGNF/cartes.gouv.fr/refs/heads/main/assets/data/topic_categories.json"
+    response = requests.get(url)
+    if response.status_code != 200:
+        return False
+    return response.json()
+
+def searchMtdUrls():
+    size = 100
+    page = 1
+    results = []
+    url = "https://data.geopf.fr/recherche/api/indexes/geoplateforme"
+    
+    while True:
+        # Paramètres de l'URL
+        params = {
+            'page': page,
+            'size': size
+        }
+        
+        # Corps de la requête
+        request_body = {
+            "metadata_urls": True
+        }
+        
+        response = requests.post(url, params=params, json=request_body)
+        if response.status_code != 200:
+            return False
+        
+        data = response.json()
+        
+        # Vérifier si le tableau documents est vide
+        if not data.get('documents') or len(data['documents']) == 0:
+            break
+            
+        # Ajouter les résultats de cette page
+        results.extend(data['documents'])
+        
+        # Passer à la page suivante
+        page += 1
+    
+    return results


### PR DESCRIPTION
- récupération des couches avec metadata_urls à true
- si ces couches contiennent une thématique on l'ajoute aux infos pour l'entrée carto
- l'edito.json écrase les infos du service de recherche 
- on converti toutes les thématiques grâce à ce fichier de conversion https://github.com/IGNF/cartes.gouv.fr/blob/main/assets/data/topic_categories.json 