### PR TITLE
Ajouter filtres thumbnail + lien vers thumbnail

### DIFF
--- a/core/entree_carto_custom.py
+++ b/core/entree_carto_custom.py
@@ -1,7 +1,9 @@
 import json
+import xml.etree.ElementTree as ET
 
 from core.config_merger import merge_edito
-from core.requester import getEdito, searchMtdUrls, getThematicConversionTable
+from core.requester import getEdito, searchMtdUrls, getThematicConversionTable, getHeadRequest, getMetadata
+from core.image_dimensions import get_image_dimensions
 
 def filter_specific_duplicates(input_dict):
     """
@@ -63,19 +65,42 @@ def filter_specific_duplicates(input_dict):
     # Créer le dictionnaire résultat
     return {k: v for k, v in input_dict.items() if k not in keys_to_remove}
 
+
+def get_valid_thumbnail(mtd_url):
+    if (mtd_url):
+        mtd_xml = getMetadata(mtd_url)
+        root = ET.fromstring(mtd_xml)  # ou ET.fromstring(xml_string)
+        # Définir les namespaces
+        ns = {
+            "gmd": "http://www.isotc211.org/2005/gmd",
+            "gco": "http://www.isotc211.org/2005/gco"
+        }
+
+        # Récupérer toutes les valeurs de fileName/CharacterString dans graphicOverview
+        urls = root.findall(".//gmd:graphicOverview/gmd:MD_BrowseGraphic/gmd:fileName/gco:CharacterString", ns)
+        for url in urls:
+            image = get_image_dimensions(url.text)
+            if image and image['width'] <= 60 and image['height'] <= 60:
+                return url.text
+    return ""
+
 def generate_entree_carto_conf(merged_config):
     edito = getEdito()
 
     # Récupère les infos idsponibles depuis le service recherche
     # en particulier "theme" et "producers"
+    print("Searching metadata urls...")
     mtd_urls_layers = searchMtdUrls()
     if mtd_urls_layers:
         for item in mtd_urls_layers:
             if 'layer_name' in item:
+                layerThumbnail = get_valid_thumbnail(next((url for url in item["metadata_urls"] if "csw?" in url), None))
                 layerType = item["type"]
                 layerName = item['layer_name']
                 layerID = layerName + "$GEOPORTAIL:OGC:" + layerType
                 if layerID in merged_config["layers"]:
+                    if layerThumbnail:
+                        merged_config["layers"][layerID]["thumbnail"] = layerThumbnail
                     if 'theme' in item:
                         merged_config["layers"][layerID]["thematic"] = list(map(str.strip, item["theme"].split(',')))
                     merged_config["layers"][layerID]["metadata_urls"] = item["metadata_urls"]

--- a/core/image_dimensions.py
+++ b/core/image_dimensions.py
@@ -1,0 +1,77 @@
+import requests
+import struct
+from core.requester import getHeadRequest
+
+
+def get_image_dimensions(url: str):
+    # --- Étape 1 : HEAD pour connaître le type ---
+    header = getHeadRequest(url)
+    content_type = header["content-type"].lower()
+
+    # --- Étape 2 : choisir max_bytes selon le type ---
+    if "png" in content_type:
+        max_bytes = 100       # PNG : très peu d’octets nécessaires
+    elif "gif" in content_type:
+        max_bytes = 100       # GIF : idem
+    elif "jpeg" in content_type or "jpg" in content_type:
+        max_bytes = 8192      # JPEG : peut contenir des métadonnées → plus gros
+    elif "webp" in content_type:
+        max_bytes = 300       # WebP : info souvent très proche du début
+    else:
+        max_bytes = 16384     # Par défaut : 16 Ko pour sécurité
+
+    # --- Étape 3 : GET partiel ---
+    headers = {"Range": f"bytes=0-{max_bytes-1}"}
+    resp = requests.get(url, headers=headers)
+    if resp.status_code not in (200, 206):
+        raise Exception(f"HTTP {resp.status_code} lors du GET partiel")
+    
+    data = resp.content
+
+    # --- Étape 4 : parser dimensions ---
+    # PNG
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        width, height = struct.unpack(">II", data[16:24])
+        return {"format": "png", "width": width, "height": height}
+
+    # GIF
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        width, height = struct.unpack("<HH", data[6:10])
+        return {"format": "gif", "width": width, "height": height}
+
+    # JPEG
+    if data[0:2] == b"\xff\xd8":
+        offset = 2
+        while offset < len(data):
+            if data[offset] != 0xFF:
+                offset += 1
+                continue
+            marker = data[offset + 1]
+            length = struct.unpack(">H", data[offset+2:offset+4])[0]
+            if 0xC0 <= marker <= 0xC3:
+                height, width = struct.unpack(">HH", data[offset+5:offset+9])
+                return {"format": "jpeg", "width": width, "height": height}
+            offset += 2 + length
+        raise Exception("JPEG : dimensions non trouvées, il faut augmenter max_bytes")
+
+    # WebP
+    if data[0:4] == b"RIFF" and data[8:12] == b"WEBP":
+        chunk = data[12:16]
+        if chunk == b"VP8 ":
+            width, height = struct.unpack("<HH", data[26:30])
+            width &= 0x3FFF
+            height &= 0x3FFF
+            return {"format": "webp", "width": width, "height": height}
+        elif chunk == b"VP8X":
+            width = 1 + int.from_bytes(data[24:27], "little")
+            height = 1 + int.from_bytes(data[27:30], "little")
+            return {"format": "webp", "width": width, "height": height}
+
+    raise Exception("Format non reconnu ou non supporté")
+
+
+# Exemple d'utilisation
+if __name__ == "__main__":
+    url = "https://example.com/image.jpg"
+    dims = get_image_dimensions(url)
+    print(dims)

--- a/core/requester.py
+++ b/core/requester.py
@@ -89,6 +89,12 @@ def getEdito():
         return False
     return response.json()
 
+def getMetadata(url):
+    response = requests.get(url)
+    if response.status_code != 200:
+        return False
+    return response.content
+
 def getThematicConversionTable():
     url = "https://raw.githubusercontent.com/IGNF/cartes.gouv.fr/refs/heads/main/assets/data/topic_categories.json"
     response = requests.get(url)
@@ -131,3 +137,9 @@ def searchMtdUrls():
         page += 1
     
     return results
+
+def getHeadRequest(url, referer=""):
+    response = requests.head(url, headers={'referer': referer})
+    if response.status_code != 200:
+        return False
+    return response.headers


### PR DESCRIPTION
En réponse à ce ticket https://github.com/IGNF/geoportal-configuration/issues/13#event-19462216442

On vérifie que les données contenant un metadata_urls possèdent un thumbnail qui respectent les contraintes de tailles : 
<60px en hauteur et largeur. ==> Pour le moment aucun thumbnail ne respect ce critère

header ne contient pas tout le temps content-length donc on télécharge partiellement les premiers octet de li'mage pour récupérer hauteur et largeur (fonctionnel pour PNG pas d'exemple jpeg sous la main)


