### PR TITLE
Inclure les métadonnées de type "STYLE_SHEET"

### DIFF
--- a/core/vectortiles_parser.py
+++ b/core/vectortiles_parser.py
@@ -46,7 +46,8 @@ def parseVectorTiles(tileMaps, key, referer):
             try:
                 if not isinstance(responseText["Metadata"], list):
                     responseText["Metadata"] = [responseText["Metadata"]]
-                styles = filter(lambda metadata : metadata["@type"] == "Other" and metadata["@mime-type"] == "application/json", responseText["Metadata"])
+                # On considère que les styles sont des métadonnées de type "OTHER" ou "STYLE_SHEET" avec un mime-type "application/json"
+                styles = filter(lambda metadata : (metadata["@type"].upper() == "OTHER" and metadata["@mime-type"] == "application/json") or (metadata["@type"].upper() == "STYLE_SHEET" and metadata["@mime-type"] == "application/json"), responseText["Metadata"])
                 styles = list(styles)
                 metadatas = list(responseText["Metadata"])
             except KeyError:
@@ -69,7 +70,7 @@ def parseVectorTiles(tileMaps, key, referer):
             finalStyles.append({
                 "name": style["@href"].split("/")[-1].split(".")[0],
                 "title": style["@href"].split("/")[-1].split(".")[0],
-                "current": current,
+                "current": current, # On suppose que le premier style est le style par défaut
                 "url": style["@href"]
                 })
             current = False


### PR DESCRIPTION
cf. https://geoplateforme-jira.ign.fr/browse/IGNGPF-5233

:warning: Prévenir la production qu'il faut utiliser le tag **STYLE_SHEET** sur les styles des TMS Vecteurs !

Exemple de procédure pour ajouter le tag **STYLE_SHEET** :
```text
// on récupère la configuration compléte
curl --request GET \
  --url https://data.geopf.fr/api/datastores/{datastore}/configurations/{configuration}
  
// on ajoute les styles avec la configuration complète
curl -X 'PUT' \
  'https://data.geopf.fr/api/datastores/{datastore}/configurations/{configuration}' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer ... \
  -H 'Content-Type: application/json' \
  -d '{
  (...)
  "metadata": [
    {
      "format": "application/json",
      "url": "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/gris.json",
      "type": "STYLE_SHEET"
    },
    {
      "format": "application/json",
      "url": "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/standard.json",
      "type": "STYLE_SHEET"
    },
    {
      "format": "application/json",
      "url": "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/sans_toponymes.json",
      "type": "STYLE_SHEET"
    },
    {
      "format": "application/json",
      "url": "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/transparent.json",
      "type": "STYLE_SHEET"
    },
    {
      "format": "application/json",
      "url": "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/attenue.json",
      "type": "STYLE_SHEET"
    },
    {
      "format": "application/json",
      "url": "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/classique.json",
      "type": "STYLE_SHEET"
    },
    {
      "format": "application/json",
      "url": "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/epure.json",
      "type": "STYLE_SHEET"
    },
    {
      "format": "application/json",
      "url": "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/toponymes.json",
      "type": "STYLE_SHEET"
    },
  ]
}'

// on met à jour l'offre
curl -X 'PUT' \
  'https://data.geopf.fr/api/datastores/{datastore}/offerings/{offering}' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer ...
```
