### PR TITLE
Filtre Thématique entrée carto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 *.tmp
+.venv

--- a/generator_entree_carto/core/post_processes.py
+++ b/generator_entree_carto/core/post_processes.py
@@ -130,7 +130,7 @@ def add_layers_default_values(layers, verbose=False):
             layer["base"] = False
     return layers
 
-def convert_thematic(layers, convert_table, verbose=False):
+def convert_thematic(layers, convert_table, verbose=False, edito=None):
     """
     Remplace les identifiants de thématiques par leur nom dans chaque couche.
 
@@ -156,10 +156,43 @@ def convert_thematic(layers, convert_table, verbose=False):
                 if t in convert_dict:
                     converted_thematics.append(convert_dict[t])
                 else:
+                    if edito and "thematics" in edito:
+                        if t in edito["thematics"]:
+                            converted_thematics.append(edito["thematics"][t])
+                            if verbose:
+                                print(f"Thématique '{t}' convertie en '{edito['thematics'][t]}' pour la couche {layer_id} grâce à l'édito")
                     converted_thematics.append(t)
                     if verbose:
                         print(f"Attention : thématique '{t}' non trouvée pour la couche {layer_id}")
             layer["thematic"] = converted_thematics
             if verbose:
                 print(f"Couche {layer_id} : thématiques converties -> {layer['thematic']}")
+    return layers
+
+def filter_thematic(layers, allowed_thematics=None, verbose=False):
+    """
+    Filtre les couches en ne gardant que celles qui ont au moins une thématique dans la liste donnée.
+    
+    Args:
+        layers (dict): Dictionnaire des couches à filtrer
+        allowed_thematics (list): Liste des thématiques à conserver
+    
+    Returns:
+        dict: Dictionnaire des couches filtrées
+    """
+        
+    if allowed_thematics:
+        # Pour chaque couche, remplacer les ids par les noms
+        for layer_id, layer in layers.items():
+            thematics = layer.get("thematic", [])
+            filtered_thematic = []
+            for t in thematics:
+                if t in allowed_thematics or t == 'Autres':
+                    filtered_thematic.append(t)
+                else:
+                    if verbose:
+                       print(f"Attention : thématique '{t}' exclue pour la couche {layer_id}")
+            if len(filtered_thematic) == 0:
+                filtered_thematic.append("Autres")
+            layer["thematic"] = filtered_thematic
     return layers

--- a/generator_entree_carto/entree_carto.py
+++ b/generator_entree_carto/entree_carto.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 
 from core.requester import getEdito, searchMtdUrls
-from core.post_processes import filter_specific_duplicates, filter_layers, add_layers_default_values, convert_thematic
+from core.post_processes import filter_specific_duplicates, filter_layers, add_layers_default_values, convert_thematic, filter_thematic
 from core.merger import merge_edito, merge_service_de_recherche_infos
 
 def getTime(verbose=False):
@@ -100,7 +100,9 @@ class GenerateEntreeCarto:
         data["layers"] = filter_specific_duplicates(data["layers"], verbose=verbose)
         # Convertit les thématiques
         data["layers"] = convert_thematic(data["layers"], edito["topics"]["thematic"], verbose=verbose)
-
+        # Filtre les thématique
+        data["layers"] = filter_thematic(data["layers"], edito["thematics"], verbose=verbose)
+        
         getTime(verbose=verbose)
         
         # Sauvegarder le JSON modifié dans un nouveau fichier


### PR DESCRIPTION
Réponse à ce ticket https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/946

On ajoute un filtre aux thématiques des couches de l'entrée carto.

Les thématiques qui ne sont pas présentes dans le fichier Edito.json seront supprimées.

Perte du mécanisme de création automatique de thématique basée sur le service de recherche.

